### PR TITLE
DRI - the_excerpt within the_content

### DIFF
--- a/class/ContentProcessor.php
+++ b/class/ContentProcessor.php
@@ -145,6 +145,10 @@ class ContentProcessor{
 
             // EnlighterJS Code detection
             add_filter('the_content', function($content) use ($T){
+                
+                if (in_array('get_the_excerpt', $GLOBALS['wp_current_filter']))
+                return $content;
+                
                 // contains enlighterjs codeblocks ?
                 $T->_hasContent = (strpos($content, 'EnlighterJSRAW') !== false);
 

--- a/class/ContentProcessor.php
+++ b/class/ContentProcessor.php
@@ -145,10 +145,10 @@ class ContentProcessor{
 
             // EnlighterJS Code detection
             add_filter('the_content', function($content) use ($T){
-                
-                if (in_array('get_the_excerpt', $GLOBALS['wp_current_filter']))
-                return $content;
-                
+                // check if the content is excerpt (e.g. for related posts), then just return the content.
+                if(in_array('get_the_excerpt', $GLOBALS['wp_current_filter'])){
+                    return $content;
+                } 
                 // contains enlighterjs codeblocks ?
                 $T->_hasContent = (strpos($content, 'EnlighterJSRAW') !== false);
 


### PR DESCRIPTION
`the_content` filter is potentially applied to related posts as well. The related posts section uses `the_excerpt()` and `the_content` filter gets applied when there is no custom excerpt is set for the post.

Let's say that I show 3 related posts, 2 x has Enlighter block and 1 x doesn't doesn't have Enlighter block, then variable `$T->_hasContent` of the plugin is set to `false` and the plugin doesn't add the necessary resources, because that one related post doesn't have enlighter within it.

This code checks if the current content being processed is excerpt. If it's excerpt (related posts), then just return the content. If not, then do the actual fun stuff.

The reason why it was working on twentynineteen is that there wasn't any other post using `the_excerpt()` function on the theme. E.g. related posts